### PR TITLE
SystemUI: Add support for black theme [1/3]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -11545,6 +11545,12 @@ public final class Settings {
         public static final String LOCKSCREEN_MEDIA_METADATA = "lockscreen_media_metadata";
 
         /**
+         * Whether to turn on black theme
+         * @hide
+         */
+        public static final String SYSTEM_BLACK_THEME = "system_black_theme";
+
+        /**
          * Keys we no longer back up under the current schema, but want to continue to
          * process when restoring historical backup datasets.
          *

--- a/packages/SystemUI/src/com/android/systemui/theme/ThemeOverlayApplier.java
+++ b/packages/SystemUI/src/com/android/systemui/theme/ThemeOverlayApplier.java
@@ -140,6 +140,7 @@ public class ThemeOverlayApplier implements Dumpable {
     private final Executor mBgExecutor;
     private final String mLauncherPackage;
     private final String mThemePickerPackage;
+    private boolean mIsBlackTheme;
 
     @Inject
     public ThemeOverlayApplier(OverlayManager overlayManager,
@@ -236,6 +237,21 @@ public class ThemeOverlayApplier implements Dumpable {
         });
     }
 
+    public void setIsBlackTheme(boolean black) {
+        mIsBlackTheme = black;
+    }
+
+    public void applyBlackTheme(boolean enable) {
+        mBgExecutor.execute(() -> {
+            try {
+                mOverlayManager.setEnabled("com.android.system.theme.black",
+                        enable, UserHandle.SYSTEM);
+            } catch (SecurityException | IllegalStateException e) {
+                Log.e(TAG, "setEnabled failed", e);
+            }
+        });
+    }
+
     @VisibleForTesting
     protected OverlayManagerTransaction.Builder getTransactionBuilder() {
         return new OverlayManagerTransaction.Builder();
@@ -248,6 +264,10 @@ public class ThemeOverlayApplier implements Dumpable {
         if (DEBUG) {
             Log.d(TAG, "setEnabled: " + identifier.getPackageName() + " category: "
                     + category + ": " + enabled);
+        }
+
+        if (OVERLAY_CATEGORY_SYSTEM_PALETTE.equals(category)) {
+            enabled = enabled && !mIsBlackTheme;
         }
 
         OverlayInfo overlayInfo = mOverlayManager.getOverlayInfo(identifier,


### PR DESCRIPTION
Squashed:

Author: Pranav Vashi <neobuddy89@gmail.com>
Date:   Sat Apr 16 10:38:36 2022 +0530

    Fixes and improvements for Black Theme

    * Add to SettingsObserver for observing toggle behavior.
    * Apply only with dark theme - looks awful on light mode.
    * Add configuration listener to reapply theme when dark mode changes.

    Change-Id: Ib114fa5772c3db74b46b7656aeb0eabdf6d4de4d

Author: Michael Bestas <mkbestas@gmail.com>
Date:   Wed Aug 24 21:19:57 2022 +0300

    Don't skip theme application if it's already current

    This fixes black theme and font/icon shape customizations.

    Change-Id: I8c3d3b4634e1ac60d28e4d5ef20bf9c2015e2e18



Change-Id: Ib165e7ba0288eaad7a1e3c1109638acdb66fa05c